### PR TITLE
Build from source tree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14-alpine3.11 as firefly-dataexchange-builder
 RUN apk add git
-RUN git clone https://github.com/kaleido-io/firefly-dataexchange-https.git
+ADD . /firefly-dataexchange-https
 WORKDIR /firefly-dataexchange-https
 RUN apk add --update python make
 RUN npm install


### PR DESCRIPTION
I believe the docker build should be building the local source tree, rather than master from Git, but I'm not 100% sure if that's the architecture of the builds.
So copying in @nguyer for a review.