### PR TITLE
Decoupling peers from config.json

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -31,6 +31,7 @@ export const constants = {
   METADATA_SUFFIX: '.metadata.json',
   RECEIVED_BLOBS_SUBDIRECTORY: 'received',
   CONFIG_FILE_NAME: 'config.json',
+  PEERS_FILE_NAME: 'peers/data.json',
   CERT_FILE: 'cert.pem',
   KEY_FILE: 'key.pem',
   CA_FILE: 'ca.pem',

--- a/src/routers/api.ts
+++ b/src/routers/api.ts
@@ -23,7 +23,7 @@ import * as blobsHandler from '../handlers/blobs';
 import * as eventsHandler from '../handlers/events';
 import * as messagesHandler from '../handlers/messages';
 import { ca, cert, key, peerID } from '../lib/cert';
-import { config, persistConfig } from '../lib/config';
+import { config, persistPeers } from '../lib/config';
 import { IStatus } from '../lib/interfaces';
 import RequestError from '../lib/request-error';
 import * as utils from '../lib/utils';
@@ -98,7 +98,7 @@ router.put('/peers/:id', async (req, res, next) => {
       };
       config.peers.push(peer);
     }
-    await persistConfig();
+    await persistPeers();
     await refreshCACerts();
     res.send({ status: 'added' });
   } catch (err) {
@@ -119,7 +119,7 @@ router.delete('/peers/:id', async (req, res, next) => {
       }
     }
     config.peers = config.peers.filter(peer => peer.id !== req.params.id);
-    await persistConfig();
+    await persistPeers();
     res.send({ status: 'removed' });
   } catch (err) {
     next(err);


### PR DESCRIPTION
After opening https://github.com/kaleido-io/firefly/pull/15, I realized `config.json` needs to be writeable soley for the sake of the `peers`. To me this indicated a difference between _config_ (provided a start time and only changeable on restart) vs _data_ (dynamic during runtime, does not require restart). Talking w/ @gabriel-indik confirmed this was a result of how DX has evolved over time.

While we could have it so that DX has init containers to copy over an initial config provided from a `Secret` to a writeable location, we get into challenges around detecting if config like `apiKey` or `p2p.endpoint` changes and having to reconcile the K8s provided config w/ the live, writeable config.

It felt easier to do the hard work now, and make `peers` a separate, writeable JSON file and have the two pieces of data get merged at load time. Additionally, if the `peers/data.json` does not exist it just sets the `peers` list to empty to avoid additional bootstrapping.

I'm wondering if `config.json`, `key.pem`, `cert.pem`, and `ca.pem` shouldn't be in an entirely separate separate folder i.e. `/config` so that the two directories can be have different permissions i.e. readable vs writeable. Looking for feedback there as opposed to having `peers/data.json` be a subfolder.